### PR TITLE
Copiloting test coverage

### DIFF
--- a/src/components/A11Y/A11Y.test.tsx
+++ b/src/components/A11Y/A11Y.test.tsx
@@ -105,7 +105,7 @@ describe('A11Y', () => {
   it('closes menu on outside click', () => {
     useIsA11yOpen.mockReturnValue(true);
     // Mock useOutsideClick to immediately call the callback (second argument)
-    useOutsideClick.mockImplementation((ref, callback) => {
+    useOutsideClick.mockImplementation((_ref, callback) => {
       callback();
       return undefined;
     });

--- a/src/components/A11Y/__tests__/A11Y.test.tsx
+++ b/src/components/A11Y/__tests__/A11Y.test.tsx
@@ -106,7 +106,7 @@ describe('A11Y', () => {
   it('closes menu on outside click', () => {
     (useIsA11yOpen as unknown as MockInstance).mockReturnValue(true);
     let outsideClickCallback: (() => void) | undefined;
-    (useOutsideClick as unknown as MockInstance).mockImplementation((ref, cb) => {
+    (useOutsideClick as unknown as MockInstance).mockImplementation((_ref, cb) => {
       outsideClickCallback = cb;
       return undefined;
     });

--- a/src/components/CustomTable/__tests__/CustomTable.test.tsx
+++ b/src/components/CustomTable/__tests__/CustomTable.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { CustomMarkdownTable } from '../CustomTable';
 

--- a/src/components/CustomTable/__tests__/tableDirective.test.ts
+++ b/src/components/CustomTable/__tests__/tableDirective.test.ts
@@ -1,4 +1,5 @@
 import { tableDirective } from '../CustomTable';
+import { unified } from 'unified';
 import type { Root } from 'mdast';
 
 describe('tableDirective plugin', () => {
@@ -14,7 +15,8 @@ describe('tableDirective plugin', () => {
         } as any,
       ],
     };
-    tableDirective()(tree as any, undefined as any, undefined as any);
+    const processor = unified().use(tableDirective);
+    processor.runSync(tree as any);
     const table = tree.children[0] as any;
     expect(table.type).toBe('table');
     expect(table.data?.hProperties?.className).toContain('table-type-footer');
@@ -34,7 +36,8 @@ describe('tableDirective plugin', () => {
         } as any,
       ],
     };
-    tableDirective()(tree as any, undefined as any, undefined as any);
+    const processor = unified().use(tableDirective);
+    processor.runSync(tree as any);
     const table = tree.children[0] as any;
     expect(table.type).toBe('table');
     expect(table.data?.hProperties?.className).toContain('table-type-footer');
@@ -51,7 +54,8 @@ describe('tableDirective plugin', () => {
         } as any,
       ],
     };
-    tableDirective()(tree as any, undefined as any, undefined as any);
+    const processor = unified().use(tableDirective);
+    processor.runSync(tree as any);
     expect(tree.children.length).toBe(0);
   });
 
@@ -68,7 +72,8 @@ describe('tableDirective plugin', () => {
         } as any,
       ],
     };
-    tableDirective()(tree as any, undefined as any, undefined as any);
+    const processor = unified().use(tableDirective);
+    processor.runSync(tree as any);
     expect(tree.children[0]).not.toBe(tableNode); // Should be a clone
   });
 });

--- a/src/components/SectionHeader/__tests__/SectionHeader.test.tsx
+++ b/src/components/SectionHeader/__tests__/SectionHeader.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import SectionHeader from '../SectionHeader';

--- a/src/components/SplashSocials/__tests__/SplashSocials.test.tsx
+++ b/src/components/SplashSocials/__tests__/SplashSocials.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../../utils/__tests__/test-utils';
 import { axe } from 'jest-axe';


### PR DESCRIPTION
This pull request primarily focuses on improving test code readability and functionality across multiple components by refining mock implementations and updating test setups. Additionally, it removes unused imports to clean up the codebase.

### Improvements to test code functionality:

* `src/components/A11Y/A11Y.test.tsx` and `src/components/A11Y/__tests__/A11Y.test.tsx`: Updated the mock implementation of `useOutsideClick` to use a placeholder variable (`_ref`) for the unused `ref` parameter, enhancing clarity in the test setup. [[1]](diffhunk://#diff-bc774a9bb0b3e8dc0912cb1602b3a1306e19259d8a775ef954318e687ae80bd2L108-R108) [[2]](diffhunk://#diff-87ddf91b0925ce50e3ba551b1c34b7d14aae137ad88b22efdc5cf75fdff820ccL109-R109)
* [`src/components/CustomTable/__tests__/tableDirective.test.ts`](diffhunk://#diff-cc9caeb2c7887f7d63e82e2ddc0838b55a3d0f496ec62521ff2eb403b703e0baL17-R19): Replaced direct calls to `tableDirective` with a processor created using `unified().use(tableDirective)` for better integration testing and consistency. [[1]](diffhunk://#diff-cc9caeb2c7887f7d63e82e2ddc0838b55a3d0f496ec62521ff2eb403b703e0baL17-R19) [[2]](diffhunk://#diff-cc9caeb2c7887f7d63e82e2ddc0838b55a3d0f496ec62521ff2eb403b703e0baL37-R40) [[3]](diffhunk://#diff-cc9caeb2c7887f7d63e82e2ddc0838b55a3d0f496ec62521ff2eb403b703e0baL54-R58) [[4]](diffhunk://#diff-cc9caeb2c7887f7d63e82e2ddc0838b55a3d0f496ec62521ff2eb403b703e0baL71-R76)

### Code cleanup:

* Removed unused `React` imports from test files (`CustomTable.test.tsx`, `SectionHeader.test.tsx`, `SplashSocials.test.tsx`) to streamline the codebase. [[1]](diffhunk://#diff-375a1dcc630fca25585276e06e12186f7dbd22e678c93b9bf0f5bbbfeb32ba01L1) [[2]](diffhunk://#diff-911fbcbc0d617c2cc258ce204eb9ea7f802e895525098c5d1308ef444469eb23L1) [[3]](diffhunk://#diff-897c59dcd0bf0a2eac9b0af32a625a89216fa24d5d9bc99057160b971e55a252L1)